### PR TITLE
Modernize boost placeholders to std

### DIFF
--- a/cogutil/opencog/util/boost_ext/accumulators/statistics/geometric_mean.h
+++ b/cogutil/opencog/util/boost_ext/accumulators/statistics/geometric_mean.h
@@ -24,9 +24,8 @@
 #define OPENCOG_UTIL_GEOMETRIC_MEAN
 
 #include  <cmath>
-
-// MODERNIZED: Replaced deprecated boost::mpl::placeholders with direct type usage
-// This eliminates dependency on deprecated boost features
+// Boost.Accumulators still binds custom tags through mpl placeholders.
+#include <boost/mpl/placeholders.hpp>
 #include <boost/accumulators/framework/accumulator_base.hpp>
 #include <boost/accumulators/framework/extractor.hpp>
 #include <boost/accumulators/numeric/functional.hpp>
@@ -91,7 +90,7 @@ namespace tag
     {
         /// INTERNAL ONLY
         ///
-        typedef accumulators::impl::geometric_mean_impl<Sample, tag::sample> impl;
+        typedef accumulators::impl::geometric_mean_impl<mpl::_1, tag::sample> impl;
     };
 
 }

--- a/cogutil/opencog/util/boost_ext/accumulators/statistics/geometric_mean_mirror.h
+++ b/cogutil/opencog/util/boost_ext/accumulators/statistics/geometric_mean_mirror.h
@@ -24,9 +24,8 @@
 #define OPENCOG_UTIL_GEOMETRIC_MEAN_MIRROR
 
 #include  <cmath>
-
-// MODERNIZED: Replaced deprecated boost::mpl::placeholders with direct type usage
-// This eliminates dependency on deprecated boost features
+// Boost.Accumulators still binds custom tags through mpl placeholders.
+#include <boost/mpl/placeholders.hpp>
 #include <boost/accumulators/framework/accumulator_base.hpp>
 #include <boost/accumulators/framework/extractor.hpp>
 #include <boost/accumulators/numeric/functional.hpp>
@@ -93,7 +92,7 @@ namespace tag
     {
         /// INTERNAL ONLY
         ///
-        typedef accumulators::impl::geometric_mean_mirror_impl<Sample, tag::sample> impl;
+        typedef accumulators::impl::geometric_mean_mirror_impl<mpl::_1, tag::sample> impl;
     };
 
 }


### PR DESCRIPTION
Revert "modernization" of Boost.Accumulators geometric mean extensions to restore compilation and correct functionality.

The previous change attempted to remove `boost::mpl::placeholders` by using direct types, but Boost.Accumulators still relies on `mpl::placeholders` for binding custom tags. This PR re-introduces the necessary `mpl::_1` and includes the corresponding header. The `sigslot.h` part of the task was verified as already using `std::placeholders`.

---
<a href="https://cursor.com/background-agent?bcId=bc-e3c3ca6a-df6a-4153-b958-6cc363245563"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e3c3ca6a-df6a-4153-b958-6cc363245563"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

